### PR TITLE
polishing the tutorial description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # ROS-TurtleBot-Tutorial
-Tutorial to run TurtleBot examples on ROS1 and ROS2
+This is a tutorial to run TurtleBot examples on ROS1 and ROS2 using a self-contained Docker environment provided via this repository. We explain two modes of navigation: teleopreation using the keyboard and setting a goal via the RViz UI. These tutorials can easily be extended for autonomous navigation too but for the scope of this tutorial, we will only discuss the above mentioned modes of navigation.
 
 ## Prerequisites
 
 ### Docker
-The Docker platform is used to install and run the container containing the simulation and the code files. Different OS platforms have different installation instructions. Checkout the getting started [link](https://docs.docker.com/get-started/) to install and run your first Docker container.
+The Docker platform is used to install and run the container containing all the necessary simulation and the code files. Different OS platforms have different installation instructions. Checkout the getting started [guide](https://docs.docker.com/get-started/) to install and run your first Docker container relevant to your OS.
 
 # ROS1 Noetic
 
@@ -23,7 +23,7 @@ The Docker Image can be installed in either of the two ways:
 
 ## Start the container
 1. Start the Docker Engine on your respective OS
-2. Start the Docker Container (One time step only, from next time onwards use step 4)
+2. Start the Docker Container (One time step only, from next time onwards use step 5)
     ```bash
     docker run --name tutorial -p 6080:80 --shm-size=512m turtlebot-tutorial
     ```


### PR DESCRIPTION
added some details for the scope of the tutorial and fixed a typo in the instructions for starting/stopping docker beyond first time use.